### PR TITLE
trie nodeに単語を追加する処理の軽量化

### DIFF
--- a/lib/rambling/trie/nodes/raw.rb
+++ b/lib/rambling/trie/nodes/raw.rb
@@ -39,7 +39,7 @@ module Rambling
         end
 
         def partial_word_chars? chars = []
-          letter = chars.slice!(0).to_sym
+          letter = chars.shift.to_sym
           child = children_tree[letter]
           return false unless child
 
@@ -47,7 +47,7 @@ module Rambling
         end
 
         def word_chars? chars = []
-          letter = chars.slice!(0).to_sym
+          letter = chars.shift.to_sym
           child = children_tree[letter]
           return false unless child
 
@@ -55,7 +55,7 @@ module Rambling
         end
 
         def closest_node chars
-          letter = chars.slice!(0).to_sym
+          letter = chars.shift.to_sym
           child = children_tree[letter]
           return missing unless child
 
@@ -67,7 +67,7 @@ module Rambling
 
           return if chars.empty?
 
-          letter = chars.slice!(0).to_sym
+          letter = chars.shift.to_sym
           child = children_tree[letter]
 
           return unless child


### PR DESCRIPTION
## 概要
池田さんが以前行ったtrie nodeへの単語追加処理の軽量化を復活させる
参考コミット 5bbe37e06d83295e2c0991e25e1a998b84e57d2d

cb652050f14f2c35039a2951e8483b666f6a2b65 のコミットで 5bbe37e06d83295e2c0991e25e1a998b84e57d2d で行った軽量化を元に戻しているのでそのRevert commitを行った


## 参考情報
池田さんが行った簡易的なベンチマーク
https://supership.slack.com/archives/G61AQ4LV9/p1725605705018079?thread_ts=1725505548.931429&cid=G61AQ4LV9

## 確認したこと
Ruby3.2.2でSpecが通ること